### PR TITLE
diverse Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ZBW Press Archives - Scripts and Templates
 
 Scripts and templates for creating and maintaining the 20th Century Press
-Archives web site https://pm20.zbw.eu . Almost all scripts work on a RDF/JSON-LD
+Archives web site https://pm20.zbw.eu . Almost all scripts work on RDF/JSON-LD
 file representations of the PM20 data. These files were created using the IFIS
 database, stored within the ZBW network. The files are available from
 [Zenodo](https://doi.org/10.5281/zenodo.11472914), further maintained by
-[Wikipedia project
+[Wikipedia Projekt
 Pressearchiv](https://de.wikipedia.org/wiki/Wikipedia:Projekt_Pressearchiv).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # ZBW Press Archives - Scripts and Templates
 
 Scripts and templates for creating and maintaining the 20th Century Press
-Archives web site https://pm20.zbw.eu . Almost all scripts work on a RDF/Turtle
-file representation of the PM20 data. That file was created using the IFIS
-database, stored within ZBW network, which is not accessed directly.
+Archives web site https://pm20.zbw.eu . Almost all scripts work on a RDF/JSON-LD
+file representations of the PM20 data. These files were created using the IFIS
+database, stored within the ZBW network. The files are available from
+[Zenodo](https://doi.org/10.5281/zenodo.11472914), further maintained by
+[Wikipedia project
+Pressearchiv](https://de.wikipedia.org/wiki/Wikipedia:Projekt_Pressearchiv).
 

--- a/create_folder_pages.pl
+++ b/create_folder_pages.pl
@@ -343,7 +343,7 @@ sub mk_folder {
       $tmpl_var{signature} = $folderdata_raw->{notation};
 
       foreach my $part (qw/country subject/) {
-        $folderdata_raw->{$part}{'@id'} =~ m;/pressemappe20(/.+)$;;
+        $folderdata_raw->{$part}{'@id'} =~ m;/pm20\.zbw\.eu(/.+)$;;
         my $url = "$1/about.$lang.html";
         $tmpl_var{"${part}_url"} = $url;
         next unless $part eq 'subject';
@@ -370,7 +370,7 @@ sub mk_folder {
       ##$tmpl_var{microfiche_period} = '1961-1998';
 
       foreach my $part (qw/country ware/) {
-        $folderdata_raw->{$part}{'@id'} =~ m;/pressemappe20(/.+)$;;
+        $folderdata_raw->{$part}{'@id'} =~ m;/pm20\.zbw\.eu(/.+)$;;
         my $url = "$1/about.$lang.html";
         $tmpl_var{"${part}_url"} = $url;
       }
@@ -391,7 +391,6 @@ sub mk_folder {
         }
       }
     }
-
     # film sections, do not exist for persons
     if ( $collection eq 'co' ) {
       my $company_id = "co/$folder_nk";

--- a/create_folder_pages.pl
+++ b/create_folder_pages.pl
@@ -228,6 +228,15 @@ sub mk_folder {
       $tmpl_var{wdlink} = $wdlink;
     }
 
+    # wikipedia link (extract for current language)
+    for my $link_ref ( @{ $folderdata_raw->{wikipediaArticle} } ) {
+      my $link = $link_ref->{'@id'};
+      if ( $link =~ m|^https://$lang\.wikipedia\.org/wiki/| ) {
+        $tmpl_var{wplink} = $link;
+        last;
+      }
+    }
+
     if ( $folderdata_raw->{temporal} ) {
       my @holdings;
       foreach my $hold ( @{ $folderdata_raw->{temporal} } ) {

--- a/create_iiif_manifest.pl
+++ b/create_iiif_manifest.pl
@@ -162,7 +162,7 @@ sub mk_folder {
 
       # feedback mailto
       my $mailto =
-          "&#109;&#97;ilto&#58;p%72essema%70pe&#50;0&#64;&#37;&#55;Ab%77&#46;eu"
+          "ma&#105;l&#116;o&#58;%69&#110;&#102;o%40zbw&#46;eu"
         . "?subject=Feedback%20zu%20PM20%20$label"
         . "&amp;body=%0D%0A%0D%0A%0D%0A---%0D%0A"
         . "https://pm20.zbw.eu/dfgview/$collection/$folder_nk";

--- a/create_mets.pl
+++ b/create_mets.pl
@@ -124,7 +124,7 @@ sub mk_folder {
 
       # feedback mailto
       my $mailto =
-          "&#109;&#97;ilto&#58;p%72essema%70pe&#50;0&#64;&#37;&#55;Ab%77&#46;eu"
+          "ma&#105;l&#116;o&#58;%69&#110;&#102;o%40zbw&#46;eu"
         . "?subject=Feedback%20zu%20PM20%20$label"
         . "&amp;body=%0D%0A%0D%0A%0D%0A---%0D%0A"
         . "https://pm20.zbw.eu/dfgview/$collection/$folder_nk";

--- a/folder_page_examples.sh
+++ b/folder_page_examples.sh
@@ -42,6 +42,9 @@ docs=(
   "wa/143120,141691"
 )
 
+# alternative quick single page set
+##docs=( "wa/143120,141691" )
+
 for folder in "${docs[@]}" ; do 
   echo https://pm20.zbw.eu/folder/$folder
   perl create_folder_pages.pl $folder ##> /dev/null

--- a/folder_page_examples.sh
+++ b/folder_page_examples.sh
@@ -3,6 +3,9 @@
 # examples for folder pages (particulary re. film sections)
 
 docs=(
+  # some of the company examples do not have wikidata links, for various
+  # reasons (Fondiaria Vita completely messed up in PM20 metadata)
+
   # Abdulla & Company - material up to 1940
   "co/046897"
 
@@ -46,7 +49,7 @@ docs=(
 ##docs=( "wa/143120,141691" )
 
 for folder in "${docs[@]}" ; do 
-  echo https://pm20.zbw.eu/folder/$folder
+  echo http://pm20.local/folder/$folder
   perl create_folder_pages.pl $folder ##> /dev/null
   make -C ../web SET=$folder > /dev/null
 done

--- a/html_tmpl/folder.md.tmpl
+++ b/html_tmpl/folder.md.tmpl
@@ -9,7 +9,7 @@ desc-meta: "<tmpl_var meta_description>"
 ---
 
 ### <tmpl_var provenance> - <tmpl_var coll><tmpl_if is_de>-Mappen</tmpl_if><tmpl_if is_en> folders</tmpl_if>
-# <tmpl_var label>&#160; <tmpl_if wdlink>[![Wikidata item](/images/Wikidata-logo.svg){.inline-icon}](<tmpl_var wdlink>)</tmpl_if>
+# <tmpl_var label>&#160; <tmpl_if wdlink>[![Wikidata item](/images/Wikidata-logo.svg){.inline-icon}](<tmpl_var wdlink>)</tmpl_if><tmpl_if wplink> [![Wikipedia](/images/Wikipedia-W.svg "Wikipedia"){.inline-icon}](<tmpl_var wplink>)</tmpl_if>
 <tmpl_if from_to>## (<tmpl_var from_to>)</tmpl_if>
 
 <div class="spacer">&#160;</div>

--- a/rebuild_all_pages.sh
+++ b/rebuild_all_pages.sh
@@ -26,3 +26,6 @@ done
 # recrate html from markdown pages
 ./web_make_all.sh
 
+# rebuild filmviewer links
+./recreate_filmviewer_links.sh
+

--- a/recreate_filmviewer_links.sh
+++ b/recreate_filmviewer_links.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # nbt, 2020-02-17
 
-# to be invoked from ite-srv24
-# now includes zotero eval and creation of filmviewer links
+# create all link snippets for filmviewer
 
 BASE_DIR=/pm20
 LOG_DIR=$BASE_DIR/web/tmp/film_meta


### PR DESCRIPTION
- automatisiert die Aktualisierung der Filmviewer Links, damit sie nicht vergessen werden kann
- behebt einen an manchen Stellen auftretenden Fehler bei der Sprachumschaltung
- behebt einen Fehler bei der Verlinkung von Warenseiten
- erlaubt bei der Entwicklung, schnell eine einzelne Beispielseit zu erzeugen
- setzt die Mailadresse auf info@zbw.eu, wo sie durch Code eingefügt wird
- fixt die fehlende Anzeige von Wikipedia-Links auf den Personen- und Firmenseiten